### PR TITLE
Fix slow anim when using a gesture to open status bar pulldown

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PanelView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PanelView.java
@@ -680,7 +680,7 @@ public abstract class PanelView extends FrameLayout {
             }
             mUpdateExpandOnLayout = isFullyCollapsed();
             mFlingAnimationUtils.apply(animator, mExpandedHeight, target, vel, getHeight());
-            if (expandBecauseOfFalsing) {
+            if (expandBecauseOfFalsing && vel == 0) {
                 animator.setDuration(350);
             }
         } else {


### PR DESCRIPTION
When using a custom launcher, like Nova, it is possible to set a
gesture to open the status bar pulldown. It does not open at the
same speed as when using a finder to pull down from the top
of the screen at the status bar. This fixes that.

Change-Id: If3f14f14ef5ed4f14495472d0335cb11d743a5a1
